### PR TITLE
Move 'contains' up front since it's typically more commonly used. Thi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ var description = regExpDescription.parse({
 
 ## Changelog
 
+* 1.1.1 Reordered `supportedOperators` to put more commonly used `contains` first.
 * 1.1.0 Added `require('mongo-regex-description').supportedOperators` array as a convenience.
 * 1.0.1 `parse()` returns null if it can't parse the query.
 * 1.0.0 Initial release

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var supportedOperators = ['is', 'is not', 'starts with', 'ends with', 'contains', 'does not contain'];
+var supportedOperators = ['contains', 'does not contain', 'is', 'is not', 'starts with', 'ends with'];
 
 /**
  * Returns a Mongo query that can be used a value for a field, given an operator and a value.


### PR DESCRIPTION
…s is for UIs that might be relying on these supported operators to show in a dropdown list.